### PR TITLE
Added Cum-Per-Penis, Multifilling Cumbuckets, Cumbucket per Sex as Flag

### DIFF
--- a/RJWSexperience/RJWSexperience/Configurations.cs
+++ b/RJWSexperience/RJWSexperience/Configurations.cs
@@ -19,6 +19,7 @@ namespace RJWSexperience
 		public const bool MinSexableFromLifestageDefault = true;
 		public const float MinSexablePercentDefault = 0.2f;
 		public const float VirginRatioDefault = 0.01f;
+        public const bool SexCanFillBucketsDefault = false;
 
 		private float maxLustDeviation = MaxInitialLustDefault;
 		private float avgLust = AvgLustDefault;
@@ -33,6 +34,7 @@ namespace RJWSexperience
 		private float minSexablePercent = MinSexablePercentDefault;
 		private float virginRatio = VirginRatioDefault;
 		private float maxSingleLustChange = MaxSingleLustChangeDefault;
+        private bool sexCanFillBuckets = SexCanFillBucketsDefault;
 
 		public float MaxLustDeviation { get => maxLustDeviation; }
 		public float AvgLust { get => avgLust; }
@@ -47,6 +49,7 @@ namespace RJWSexperience
 		public float MinSexablePercent { get => minSexablePercent; }
 		public float VirginRatio { get => virginRatio; }
 		public float MaxSingleLustChange { get => maxSingleLustChange; }
+        public bool SexCanFillBuckets { get => sexCanFillBuckets; }
 
 		private bool selectionLocked = false;
 
@@ -68,6 +71,7 @@ namespace RJWSexperience
 			minSexableFromLifestage = MinSexableFromLifestageDefault;
 			minSexablePercent = MinSexablePercentDefault;
 			virginRatio = VirginRatioDefault;
+            sexCanFillBuckets = SexCanFillBucketsDefault;
 		}
 
 		public override void ExposeData()
@@ -86,6 +90,7 @@ namespace RJWSexperience
 			Scribe_Values.Look(ref minSexablePercent, "MinSexablePercent", MinSexablePercentDefault, true);
 			Scribe_Values.Look(ref virginRatio, "VirginRatio", VirginRatioDefault, true);
 			Scribe_Values.Look(ref selectionLocked, "SelectionLocked");
+            Scribe_Values.Look(ref sexCanFillBuckets, "SexCanFillBuckets", SexCanFillBucketsDefault, true);
 			base.ExposeData();
 		}
 
@@ -127,6 +132,9 @@ namespace RJWSexperience
 			}
 
 			listmain.CheckboxLabeled(Keyed.Option_EnableBastardRelation_Label, ref enableBastardRelation, Keyed.Option_EnableBastardRelation_Desc);
+
+
+            listmain.CheckboxLabeled("SexCanFillBuckets".Translate(), ref sexCanFillBuckets, "SexCanFillBuckets_desc".Translate());
 
 			if (listmain.ButtonText(Keyed.Button_ResetToDefault))
 			{

--- a/RJWSexperience/RJWSexperience/ExtensionMethods/PawnExtensions.cs
+++ b/RJWSexperience/RJWSexperience/ExtensionMethods/PawnExtensions.cs
@@ -46,6 +46,25 @@ namespace RJWSexperience
 			return null;
 		}
 
+		public static IEnumerable<T> GetAdjacentBuildings<T>(this Pawn pawn) where T : Building
+		{	
+			// This Method was introduced to fill multiple CumBuckets around a single pawn.
+			var results = new List<T>();
+			if (pawn.Spawned)
+			{
+				EdificeGrid edifice = pawn.Map.edificeGrid;
+				if (edifice[pawn.Position] is T)
+					results.Add((T)edifice[pawn.Position]);
+				IEnumerable<IntVec3> adjcells = GenAdjFast.AdjacentCells8Way(pawn.Position);
+				foreach (IntVec3 pos in adjcells)
+				{
+					if (edifice[pos] is T)
+						results.Add((T)edifice[pos]);
+				}
+			}
+			return results;
+		}
+
 		public static float GetCumVolume(this Pawn pawn)
 		{
 			List<Hediff> hediffs = Genital_Helper.get_PartsHediffList(pawn, Genital_Helper.get_genitalsBPR(pawn));
@@ -55,12 +74,21 @@ namespace RJWSexperience
 
 		public static float GetCumVolume(this Pawn pawn, List<Hediff> hediffs)
 		{
-			CompHediffBodyPart part = hediffs?.FindAll((Hediff hed) => hed.def.defName.ToLower().Contains("penis")).InRandomOrder().FirstOrDefault()?.TryGetComp<CompHediffBodyPart>();
-			if (part == null) part = hediffs?.FindAll((Hediff hed) => hed.def.defName.ToLower().Contains("ovipositorf")).InRandomOrder().FirstOrDefault()?.TryGetComp<CompHediffBodyPart>();
-			if (part == null) part = hediffs?.FindAll((Hediff hed) => hed.def.defName.ToLower().Contains("ovipositorm")).InRandomOrder().FirstOrDefault()?.TryGetComp<CompHediffBodyPart>();
-			if (part == null) part = hediffs?.FindAll((Hediff hed) => hed.def.defName.ToLower().Contains("tentacle")).InRandomOrder().FirstOrDefault()?.TryGetComp<CompHediffBodyPart>();
+			float cum_value = 0;
+			// Add Cum for every existing Penis at the pawn
+			foreach (var penis in hediffs?.FindAll((Hediff hed) => hed.def.defName.ToLower().Contains("penis")))
+			{
+				cum_value += pawn.GetCumVolume(penis.TryGetComp<CompHediffBodyPart>());
+			}
+			// Look for more exotic parts - if any is found, add some more cum for the first special part found
+			CompHediffBodyPart special_part = null;
+			if (special_part == null) special_part = hediffs?.FindAll((Hediff hed) => hed.def.defName.ToLower().Contains("ovipositorf")).InRandomOrder().FirstOrDefault()?.TryGetComp<CompHediffBodyPart>();
+			if (special_part == null) special_part = hediffs?.FindAll((Hediff hed) => hed.def.defName.ToLower().Contains("ovipositorm")).InRandomOrder().FirstOrDefault()?.TryGetComp<CompHediffBodyPart>();
+			if (special_part == null) special_part = hediffs?.FindAll((Hediff hed) => hed.def.defName.ToLower().Contains("tentacle")).InRandomOrder().FirstOrDefault()?.TryGetComp<CompHediffBodyPart>();
 
-			return pawn.GetCumVolume(part);
+			cum_value += pawn.GetCumVolume(special_part);
+
+			return cum_value;
 		}
 
 		public static float GetCumVolume(this Pawn pawn, CompHediffBodyPart part)


### PR DESCRIPTION
Hi, 

as per short chat in the Discord here are some small changes I have made: 

- Cum Amount for filling buckets is sum of all penis of a pawn
- Cum is spread out evenly among all nearby buckets
- When a Configuration is set (default to false, so current behaviour is untouched) getting a Handjob, Boobjob or Footjob also fills the nearby cum-buckets (based on donators position)

